### PR TITLE
Add latin1 encoding to SQLAlchemy engines

### DIFF
--- a/db.py
+++ b/db.py
@@ -19,7 +19,13 @@ class DBManager:
                 "DB_LOCAL_URL",
                 "postgresql://postgres:password@localhost:5432/jergo_local",
             )
-            return create_engine(db_url, echo=False, pool_size=1, max_overflow=0)
+            return create_engine(
+                db_url,
+                echo=False,
+                pool_size=1,
+                max_overflow=0,
+                connect_args={"client_encoding": "latin1"},
+            )
         else:
             print("📡 Modo seleccionado: NUBE")
             db_url = os.getenv(
@@ -32,6 +38,7 @@ class DBManager:
                 max_overflow=20,
                 pool_recycle=1800,
                 pool_timeout=30,
+                connect_args={"client_encoding": "latin1"},
             )
 
     def obtener_dataframe(self, query: str, params: dict | None = None) -> pd.DataFrame:

--- a/sincronizador.py
+++ b/sincronizador.py
@@ -7,8 +7,16 @@ from sqlalchemy.exc import SQLAlchemyError
 DB_LOCAL_URL = os.getenv("DB_LOCAL_URL", "postgresql://postgres:password@localhost/jergo_local")
 DB_ONLINE_URL = os.getenv("DB_ONLINE_URL", "postgresql://user:pass@host/jergo_db?sslmode=require")
 
-engine_local = create_engine(DB_LOCAL_URL, pool_pre_ping=True)
-engine_online = create_engine(DB_ONLINE_URL, pool_pre_ping=True)
+engine_local = create_engine(
+    DB_LOCAL_URL,
+    pool_pre_ping=True,
+    connect_args={"client_encoding": "latin1"},
+)
+engine_online = create_engine(
+    DB_ONLINE_URL,
+    pool_pre_ping=True,
+    connect_args={"client_encoding": "latin1"},
+)
 
 # 🔁 Orden correcto de tablas según relaciones foráneas
 ORDEN_DEPENDENCIAS = [


### PR DESCRIPTION
## Summary
- ensure Latin-1 encoding is used when connecting to PostgreSQL
- apply same encoding to local and online sync engines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685c1610622483249ff681f3a5faa9a9