### PR TITLE
Use unified decode helper across UI modules

### DIFF
--- a/db.py
+++ b/db.py
@@ -6,6 +6,16 @@ import pandas as pd
 import config
 
 
+def decodificar(valor):
+    """Decode bytes using latin1, returning a placeholder on failure."""
+    if isinstance(valor, bytes):
+        try:
+            return valor.decode("latin1")
+        except Exception:
+            return "??"
+    return valor
+
+
 class DBManager:
     def __init__(self):
         self.modo = config.modo_operacion
@@ -40,14 +50,6 @@ class DBManager:
                 result = conn.execute(text(query), params or {})
                 rows = result.fetchall()
                 cols = result.keys()
-
-                def decodificar(valor):
-                    if isinstance(valor, bytes):
-                        try:
-                            return valor.decode("latin1")
-                        except Exception:
-                            return "??"
-                    return valor
 
                 data_limpia = [[decodificar(val) for val in row] for row in rows]
                 return pd.DataFrame(data_limpia, columns=cols)

--- a/selector_proyecto.py
+++ b/selector_proyecto.py
@@ -1,6 +1,6 @@
 from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QComboBox, QPushButton, QMessageBox
 from sqlalchemy import text
-from db import DBManager
+from db import DBManager, decodificar
 import config
 
 class SelectorProyectoDialog(QDialog):
@@ -36,10 +36,7 @@ class SelectorProyectoDialog(QDialog):
                     id_proyecto = row[0]
                     nombre = row[1]
                     if isinstance(nombre, bytes):
-                        try:
-                            nombre = nombre.decode("latin1")
-                        except:
-                            nombre = "??"
+                        nombre = decodificar(nombre)
                     texto = f"{id_proyecto} - {nombre}"
                     self.combo.addItem(texto, id_proyecto)
         except Exception as e:

--- a/vista_editor_apus.py
+++ b/vista_editor_apus.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QTableView, QMessageBox, QPushButton, QHBoxLayout
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from sqlalchemy import text
-from db import DBManager
+from db import DBManager, decodificar
 import config
 from vista_editor_sub_apu import SubAPUEditor
 from vista_editor_insumos import crear_editor_insumos
@@ -96,7 +96,7 @@ class EditorAPUs(QWidget):
                 for row in rows:
                     items = []
                     for val in row[:-2]:
-                        val = val.decode("latin1") if isinstance(val, bytes) else val
+                        val = decodificar(val)
                         items.append(QStandardItem(str(val)))
                     self.model.appendRow(items)
 

--- a/vista_editor_partidas.py
+++ b/vista_editor_partidas.py
@@ -2,7 +2,7 @@ from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QComboBox
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from sqlalchemy import text
-from db import DBManager
+from db import DBManager, decodificar
 import config
 from filtros import cargar_tipo_partidas
 from vista_editor_apus import crear_editor_apus
@@ -78,11 +78,7 @@ class EditorPartidas(QWidget):
                 for row in result:
                     items = []
                     for val in row:
-                        if isinstance(val, bytes):
-                            try:
-                                val = val.decode("latin1")
-                            except Exception:
-                                val = "??"
+                        val = decodificar(val)
                         items.append(QStandardItem(str(val)))
                     self.model.appendRow(items)
         except Exception as e:

--- a/vista_editor_proyectos.py
+++ b/vista_editor_proyectos.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QPushButton, QTableView, QMessageBox
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from sqlalchemy import text
-from db import DBManager
+from db import DBManager, decodificar
 
 
 class EditorProyectos(QWidget):
@@ -42,11 +42,7 @@ class EditorProyectos(QWidget):
                 for row in result:
                     items = []
                     for valor in row:
-                        if isinstance(valor, bytes):
-                            try:
-                                valor = valor.decode('latin1')
-                            except:
-                                valor = "??"
+                        valor = decodificar(valor)
                         items.append(QStandardItem(str(valor)))
                     self.model.appendRow(items)
         except Exception as e:

--- a/vista_editor_sub_apu.py
+++ b/vista_editor_sub_apu.py
@@ -1,6 +1,6 @@
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QTableView, QMessageBox
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
-from db import DBManager
+from db import DBManager, decodificar
 import config
 from sqlalchemy import text
 
@@ -53,11 +53,7 @@ class SubAPUEditor(QWidget):
                 for row in result:
                     items = []
                     for val in row:
-                        if isinstance(val, bytes):
-                            try:
-                                val = val.decode("latin1")
-                            except Exception:
-                                val = "??"
+                        val = decodificar(val)
                         items.append(QStandardItem(str(val)))
                     self.model.appendRow(items)
         except Exception as e:


### PR DESCRIPTION
## Summary
- expose `decodificar()` at module level in `db.py`
- reuse `decodificar()` in selector dialogs and editors
- keep `db.obtener_dataframe()` decoding via the helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685c16128be083249d9aa83e9c3ffbf2